### PR TITLE
ws-over-http keepalives

### DIFF
--- a/src/subscriptions-transport-ws-over-http/GraphqlWebSocketOverHttpConnectionListener.ts
+++ b/src/subscriptions-transport-ws-over-http/GraphqlWebSocketOverHttpConnectionListener.ts
@@ -5,9 +5,7 @@ import * as grip from "grip";
 
 interface IOnOpenResponse {
   /** response headers */
-  headers: {
-    [key: string]: string;
-  };
+  headers: Record<string, string>;
 }
 
 /**
@@ -111,6 +109,11 @@ export const isGraphqlWsStopMessage = (o: any): o is IGraphqlWsStopMessage => {
 export interface IGraphqlWebSocketOverHttpConnectionListenerOptions {
   /** Info about the WebSocket-Over-HTTP Connection */
   connection: IWebSocketOverHTTPConnectionInfo;
+  /** WebSocket-Over-HTTP options */
+  webSocketOverHttp?: {
+    /** how often to ask ws-over-http gateway to make keepalive requests */
+    keepAliveIntervalSeconds?: number;
+  };
   /** Handle a websocket message and optionally return a response */
   getMessageResponse(message: string): void | string | Promise<string | void>;
   /**
@@ -122,8 +125,8 @@ export interface IGraphqlWebSocketOverHttpConnectionListenerOptions {
 }
 
 /**
- * Connection Listener that tries to mock out a basic graphql-ws.
- * It's also grip and WebSocket-Over-HTTP aware.
+ * GraphqlWebSocketOverHttpConnectionListener
+ * WebSocket-Over-HTTP Connection Listener that tries to mock out a basic graphql-ws.
  */
 export default (
   options: IGraphqlWebSocketOverHttpConnectionListenerOptions,
@@ -153,8 +156,17 @@ export default (
       return options.getMessageResponse(message);
     },
     async onOpen() {
-      const headers = {
-        "sec-websocket-protocol": "graphql-ws",
+      const webSocketOverHttpOptions = options.webSocketOverHttp;
+      const keepAliveIntervalSeconds =
+        webSocketOverHttpOptions &&
+        webSocketOverHttpOptions.keepAliveIntervalSeconds;
+      const headers: Record<string, string> = {
+        ...(options.connection.protocol
+          ? { "sec-websocket-protocol": options.connection.protocol }
+          : {}),
+        ...(keepAliveIntervalSeconds && keepAliveIntervalSeconds < Infinity
+          ? { "Keep-Alive-Interval": String(keepAliveIntervalSeconds) }
+          : {}),
       };
       return { headers };
     },

--- a/src/subscriptions-transport-ws-over-http/GraphqlWsOverWebSocketOverHttpExpressMiddleware.ts
+++ b/src/subscriptions-transport-ws-over-http/GraphqlWsOverWebSocketOverHttpExpressMiddleware.ts
@@ -120,6 +120,11 @@ const composeMessageHandlers = (
 interface IGraphqlWsOverWebSocketOverHttpExpressMiddlewareOptions {
   /** table to store information about each Graphql Subscription */
   subscriptionStorage: ISimpleTable<IGraphqlSubscription>;
+  /** WebSocket-Over-HTTP options */
+  webSocketOverHttp?: {
+    /** how often to ask ws-over-http gateway to make keepalive requests */
+    keepAliveIntervalSeconds?: number;
+  };
   /** Given a graphql-ws GQL_START message, return a string that is the Grip-Channel that the GRIP server should subscribe to for updates */
   getGripChannel(gqlStartMessage: IGraphqlWsStartMessage): string;
   /** Called when a new subscrpition connection is made */
@@ -140,6 +145,11 @@ export const GraphqlWsOverWebSocketOverHttpExpressMiddleware = (
       const graphqlWsConnectionListener = GraphqlWebSocketOverHttpConnectionListener(
         {
           connection,
+          getMessageResponse: AcceptAllGraphqlSubscriptionsMessageHandler(),
+          webSocketOverHttp: {
+            keepAliveIntervalSeconds: 120,
+            ...options.webSocketOverHttp,
+          },
           async getGripChannel(graphqlWsMessage) {
             const startMessage: IGraphqlWsStartMessage = isGraphqlWsStartMessage(
               graphqlWsMessage,
@@ -190,7 +200,6 @@ export const GraphqlWsOverWebSocketOverHttpExpressMiddleware = (
             const gripChannel = options.getGripChannel(startMessage);
             return gripChannel;
           },
-          getMessageResponse: AcceptAllGraphqlSubscriptionsMessageHandler(),
         },
       );
       const { subscriptionStorage } = options;

--- a/src/websocket-over-http-express/WebSocketOverHttpExpress.ts
+++ b/src/websocket-over-http-express/WebSocketOverHttpExpress.ts
@@ -58,11 +58,11 @@ export default (
           options.gripPrefix,
         );
         if (!events.length) {
-          return res
-            .status(400)
-            .end(
-              "Failed to parse any events from application/websocket-events",
-            );
+          // No events. This may be a ws-over-http KeepAlive request.
+          console.debug(
+            "WebSocketOverHttpExpress got WebSocket-Over-Http request with zero events. May be keepalive.",
+            new Date(Date.now()),
+          );
         }
         if (!connectionId) {
           throw new Error(`Expected connection-id header but none is present`);


### PR DESCRIPTION
GraphqlWsOverWebSocketOverHttpExpressMiddleware can configure options.webSocketOverHttp.keepAliveIntervalSeconds. It defaults to 120s