### PR TITLE
Travis CI does linty checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,14 +15,16 @@
   },
   "scripts": {
     "build": "npm run tsc",
-    "check-and-build": "npm run prettier:check && npm run tslint && npm run build",
+    "check": "npm run prettier:check && npm run tsc:check && npm run tslint",
+    "check-and-build": "npm run check && npm run build",
     "prettier": "prettier '{package.json,tsconfig.json,src/**/*.{ts,tsx}}' --write",
     "prettier:check": "prettier '{package.json,tsconfig.json,src/**/*.{ts,tsx}}' --check",
     "prepublishOnly": "npm run check-and-build",
     "preversion": "npm run check-and-build",
     "start": "ts-node src/FanoutGraphqlExpressServer",
-    "test": "ts-node src/test/unit",
+    "test": "ts-node src/test/unit && npm run check",
     "tsc": "tsc -p tsconfig.json",
+    "tsc:check": "npm run tsc -- --noEmit",
     "tslint": "tslint -c tslint.json 'src/**/*.ts'"
   },
   "dependencies": {

--- a/src/subscriptions-transport-ws-over-http/GraphqlWsOverWebSocketOverHttpExpressMiddleware.ts
+++ b/src/subscriptions-transport-ws-over-http/GraphqlWsOverWebSocketOverHttpExpressMiddleware.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as express from "express";
-import { assertNever } from "fanout-graphql-tools/src/graphql-epcp-pubsub/EpcpPubSubMixin";
 import { v4 as uuidv4 } from "uuid";
+import { assertNever } from "../graphql-epcp-pubsub/EpcpPubSubMixin";
 import { default as AcceptAllGraphqlSubscriptionsMessageHandler } from "../graphql-ws/AcceptAllGraphqlSubscriptionsMessageHandler";
 import { filterTable, ISimpleTable } from "../simple-table/SimpleTable";
 import WebSocketOverHttpExpress from "../websocket-over-http-express/WebSocketOverHttpExpress";


### PR DESCRIPTION
Last PR let in a compiler error fixed by this commit: https://github.com/fanout/fanout-graphql-tools/commit/adcefed98c266db03e1a3fb47f8b8a8910a76891

This PR also makes travis run `tsc`, `prettier`, and `tslint` on `npm test`