### PR TITLE
Add GraphqlWsOverWebSocketOverHttpExpressMiddlewareTest.test.ts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "ts-node Current File",
+      "type": "node",
+      "request": "launch",
+      "args": ["${relativeFile}"],
+      "runtimeArgs": [
+        "--nolazy",
+        "--preserve-symlinks",
+        "--preserve-symlinks-main",
+        "-r", "ts-node/register"
+      ],
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector",
+      "internalConsoleOptions": "openOnSessionStart",
+      "outputCapture": "std",
+      "sourceMaps": true,
+      "env": {
+        "LOG_LEVEL": "debug",
+        "TEST_TIMEOUT_MS": "60000",
+        "PUSHPIN_PROXY_URL": "http://localhost:7999",
+      }
+    },
+  ]
+}

--- a/src/@types/killable/index.d.ts
+++ b/src/@types/killable/index.d.ts
@@ -1,0 +1,13 @@
+declare module "killable" {
+  import { Server } from "http";
+  type KillableServerType = Server & {
+    /** kill the http server, closing all connections */
+    kill: (errback: (error?: Error) => void) => void;
+  };
+  // tslint:disable-next-line:completed-docs
+  function killable(server: Server): KillableServerType;
+  namespace killable {
+    export type KillableServer = KillableServerType;
+  }
+  export = killable;
+}

--- a/src/graphql-epcp-pubsub/EpcpPubSubMixin.ts
+++ b/src/graphql-epcp-pubsub/EpcpPubSubMixin.ts
@@ -76,9 +76,9 @@ export const EpcpPubSubMixin = (options: IEpcpPubSubMixinOptions) => (
     grip.parseGripUri(options.grip.url),
   );
   return {
-    asyncIterator: pubsub.asyncIterator,
-    subscribe: pubsub.subscribe,
-    unsubscribe: pubsub.unsubscribe,
+    asyncIterator: pubsub.asyncIterator.bind(pubsub),
+    subscribe: pubsub.subscribe.bind(pubsub),
+    unsubscribe: pubsub.unsubscribe.bind(pubsub),
     async publish(triggerName: string, payload: any) {
       await pubsub.publish(triggerName, payload);
       const epcpPublishes = await options.epcpPublishForPubSubEnginePublish({

--- a/src/simple-graphql-api/SimpleGraphqlApi.ts
+++ b/src/simple-graphql-api/SimpleGraphqlApi.ts
@@ -1,0 +1,235 @@
+import { PubSub, PubSubEngine } from "apollo-server";
+import { GraphQLSchema } from "graphql";
+import gql from "graphql-tag";
+import {
+  IEpcpPublish,
+  IPubSubEnginePublish,
+  returnTypeNameForSubscriptionFieldName,
+} from "../graphql-epcp-pubsub/EpcpPubSubMixin";
+import { filterTable, ISimpleTable } from "../simple-table/SimpleTable";
+import { IGraphqlSubscription } from "../subscriptions-transport-ws-over-http/GraphqlSubscription";
+import {
+  getSubscriptionOperationFieldName,
+  IGraphqlWsStartMessage,
+  isGraphqlWsStartMessage,
+} from "../subscriptions-transport-ws-over-http/GraphqlWebSocketOverHttpConnectionListener";
+import { gripChannelForSubscriptionWithoutArguments } from "../subscriptions-transport-ws-over-http/GraphqlWsGripChannelNamers";
+
+interface IPost {
+  /** post author */
+  author: string;
+  /** post body text */
+  comment: string;
+}
+
+interface IPostController {
+  /** add a post */
+  addPost(post: IPost): IPost;
+  /** get all posts */
+  posts(): IPost[];
+}
+
+/** Constructor for a PostController that stores post in memory */
+const PostController = (): IPostController => {
+  const postStorage: IPost[] = [];
+  const addPost = (post: IPost): IPost => {
+    postStorage.push(post);
+    return post;
+  };
+  const posts = (): IPost[] => {
+    return postStorage.slice();
+  };
+  return {
+    addPost,
+    posts,
+  };
+};
+
+enum SimpleGraphqlApiPubSubTopic {
+  POST_ADDED = "POST_ADDED",
+}
+
+/** Common Subscription queries that can be passed to ApolloClient.subscribe() */
+export const SimpleGraphqlApiSubscriptions = {
+  postAdded() {
+    return {
+      query: gql`
+        subscription {
+          postAdded {
+            author
+            comment
+          }
+        }
+      `,
+      variables: {},
+    };
+  },
+};
+
+/** Factories for common mutations that can be passed to apolloClient.mutate() */
+export const SimpleGraphqlApiMutations = {
+  addPost(post: IPost) {
+    return {
+      mutation: gql`
+        mutation AddPost($author: String!, $comment: String!) {
+          addPost(author: $author, comment: $comment) {
+            author
+            comment
+          }
+        }
+      `,
+      variables: post,
+    };
+  },
+};
+
+interface ISimpleGraphqlApiOptions {
+  /** controller that will handle storing/retrieving posts */
+  postController?: IPostController;
+  /** pubsub implementation that will be used by the gql schema resolvers */
+  pubsub?: PubSubEngine;
+}
+
+/**
+ * A GraphQL API from the apollo-server subscriptions docs: https://www.apollographql.com/docs/apollo-server/features/subscriptions/
+ */
+export const SimpleGraphqlApi = ({
+  pubsub = new PubSub(),
+  postController = PostController(),
+}: ISimpleGraphqlApiOptions = {}) => {
+  const typeDefs = gql`
+    type Subscription {
+      postAdded: Post
+    }
+
+    type Query {
+      posts: [Post]
+    }
+
+    type Mutation {
+      addPost(author: String, comment: String): Post
+    }
+
+    type Post {
+      author: String
+      comment: String
+    }
+  `;
+  const resolvers = {
+    Mutation: {
+      addPost(root: any, args: any, context: any) {
+        pubsub.publish(SimpleGraphqlApiPubSubTopic.POST_ADDED, {
+          postAdded: args,
+        });
+        return postController.addPost(args);
+      },
+    },
+    Query: {
+      posts(root: any, args: any, context: any) {
+        return postController.posts();
+      },
+    },
+    Subscription: {
+      postAdded: {
+        // Additional event labels can be passed to asyncIterator creation
+        subscribe: () =>
+          pubsub.asyncIterator([SimpleGraphqlApiPubSubTopic.POST_ADDED]),
+      },
+    },
+  };
+  return {
+    resolvers,
+    typeDefs,
+  };
+};
+
+/** Return a function that will return the Grip-Channel to use for each graphql-ws start message */
+export const SimpleGraphqlApiGripChannelNamer = () => (
+  gqlWsStartMessage: IGraphqlWsStartMessage,
+): string => {
+  return gripChannelForSubscriptionWithoutArguments(gqlWsStartMessage);
+};
+
+type PubSubEngineEpcpPublisher = (
+  publish: IPubSubEnginePublish,
+) => Promise<IEpcpPublish[]>;
+
+/**
+ * Convert SimpleGraphqlApi PubSubEngine publishes to EPCP Publishes that should be sent to a GRIP server.
+ */
+export const SimpleGraphqlApiEpcpPublisher = (options: {
+  /** GraphQL Schema */
+  graphqlSchema: GraphQLSchema;
+  /** storage table for graphql-ws subscriptions */
+  subscriptionStorage: ISimpleTable<IGraphqlSubscription>;
+}): PubSubEngineEpcpPublisher => async (
+  pubsubEnginePublish: IPubSubEnginePublish,
+) => {
+  switch (pubsubEnginePublish.triggerName) {
+    case SimpleGraphqlApiPubSubTopic.POST_ADDED:
+      const postAddedSubscriptions = await filterTable(
+        options.subscriptionStorage,
+        (subscription: IGraphqlSubscription) =>
+          subscription.subscriptionFieldName === "postAdded",
+      );
+      // get a start message from one of the subscriptions
+      const getStartMessageSample = () => {
+        const subscription = postAddedSubscriptions[0];
+        const startMessageSample =
+          subscription && JSON.parse(subscription.startMessage);
+        if (!isGraphqlWsStartMessage(startMessageSample)) {
+          throw new Error(
+            `Could not get sample startMessage, got ${startMessageSample}`,
+          );
+        }
+        return startMessageSample;
+      };
+      const epcpPublishes: IEpcpPublish[] = postAddedSubscriptions
+        .map(s => s.operationId)
+        .reduce(uniqueReducer, [] as string[])
+        .map(operationId => {
+          const startMessageBase = getStartMessageSample();
+          const subscriptionFieldName = getSubscriptionOperationFieldName(
+            startMessageBase.payload,
+          );
+          const epcpPublish: IEpcpPublish = {
+            channel: SimpleGraphqlApiGripChannelNamer()({
+              ...startMessageBase,
+              id: operationId,
+            }),
+            message: JSON.stringify({
+              id: operationId,
+              payload: {
+                data: {
+                  [subscriptionFieldName]: {
+                    __typename: returnTypeNameForSubscriptionFieldName(
+                      options.graphqlSchema,
+                      subscriptionFieldName,
+                    ),
+                    ...pubsubEnginePublish.payload[subscriptionFieldName],
+                  },
+                },
+              },
+              type: "data",
+            }),
+          };
+          return epcpPublish;
+        });
+
+      return epcpPublishes;
+  }
+  throw new Error(
+    `SimpleGraphqlApiEpcpPublisher got unexpected PubSubEngine triggerName ${pubsubEnginePublish.triggerName} `,
+  );
+};
+
+/** Array reducer that returns an array of the unique items of the reduced array */
+function uniqueReducer<Item>(prev: Item[] | Item, curr: Item): Item[] {
+  if (!Array.isArray(prev)) {
+    prev = [prev];
+  }
+  if (prev.indexOf(curr) === -1) {
+    prev.push(curr);
+  }
+  return prev;
+}

--- a/src/subscriptions-transport-ws-over-http/GraphqlWsGripChannelNamers.ts
+++ b/src/subscriptions-transport-ws-over-http/GraphqlWsGripChannelNamers.ts
@@ -1,0 +1,36 @@
+import * as querystring from "querystring";
+import {
+  getSubscriptionOperationFieldName,
+  IGraphqlWsStartMessage,
+} from "./GraphqlWebSocketOverHttpConnectionListener";
+
+/**
+ * A function that will return the Grip-Channel to use for the provided IGraphqlWsStartMessage.
+ * This will only work for GraphQL APIs with subscriptions that dont have arguments.
+ * The Grip-Channel will be based on the subscription field name + the graphqlWsStartMessage operation id
+ */
+export const gripChannelForSubscriptionWithoutArguments = (
+  graphqlWsStartMessage: IGraphqlWsStartMessage,
+): string => {
+  const subscriptionFieldName = getSubscriptionOperationFieldName(
+    graphqlWsStartMessage.payload,
+  );
+  const gripChannel = `${subscriptionFieldName}?${querystring.stringify(
+    sorted({
+      "subscription.operation.id": graphqlWsStartMessage.id,
+    }),
+  )}`;
+  return gripChannel;
+};
+
+/**
+ * given an object, return the same, ensuring that the object keys were inserted in alphabetical order
+ * https://github.com/nodejs/node/issues/6594#issuecomment-217120402
+ */
+function sorted(o: any) {
+  const p = Object.create(null);
+  for (const k of Object.keys(o).sort()) {
+    p[k] = o[k];
+  }
+  return p;
+}

--- a/src/subscriptions-transport-ws-over-http/GraphqlWsOverWebSocketOverHttpExpressMiddlewareTest.test.ts
+++ b/src/subscriptions-transport-ws-over-http/GraphqlWsOverWebSocketOverHttpExpressMiddlewareTest.test.ts
@@ -1,0 +1,260 @@
+import {
+  AsyncTest,
+  Expect,
+  FocusTest,
+  IgnoreTest,
+  TestCase,
+  TestFixture,
+  Timeout,
+} from "alsatian";
+import {
+  buildSchemaFromTypeDefinitions,
+  IResolvers,
+  PubSub,
+  PubSubEngine,
+} from "apollo-server-express";
+import { ApolloServer } from "apollo-server-express";
+import * as express from "express";
+import { DocumentNode } from "graphql";
+import gql from "graphql-tag";
+import * as http from "http";
+import * as urlModule from "url";
+import {
+  EpcpPubSubMixin,
+  IEpcpPublish,
+  IPubSubEnginePublish,
+} from "../graphql-epcp-pubsub/EpcpPubSubMixin";
+import {
+  SimpleGraphqlApi,
+  SimpleGraphqlApiEpcpPublisher,
+  SimpleGraphqlApiGripChannelNamer,
+  SimpleGraphqlApiMutations,
+  SimpleGraphqlApiSubscriptions,
+} from "../simple-graphql-api/SimpleGraphqlApi";
+import { ISimpleTable, MapSimpleTable } from "../simple-table/SimpleTable";
+import { cli } from "../test/cli";
+import { ChangingValue } from "../testing-tools/ChangingValue";
+import { itemsFromLinkObservable } from "../testing-tools/itemsFromLinkObservable";
+import WebSocketApolloClient from "../testing-tools/WebSocketApolloClient";
+import { withListeningServer } from "../testing-tools/withListeningServer";
+import { IGraphqlSubscription } from "./GraphqlSubscription";
+import { IGraphqlWsStartMessage } from "./GraphqlWebSocketOverHttpConnectionListener";
+import GraphqlWsOverWebSocketOverHttpExpressMiddleware from "./GraphqlWsOverWebSocketOverHttpExpressMiddleware";
+
+interface ISubscriptionsListener {
+  /** called on subscription start */
+  onConnect: (...args: any[]) => void;
+}
+
+interface IGraphqlHttpAppOptions {
+  /** configure graphql API */
+  graphql: {
+    /** GraphQL API typeDefs */
+    typeDefs: DocumentNode;
+    /** get resolvers for GraphQL API */
+    getResolvers(options: {
+      /** PubSubEngine to use in resolvers */
+      pubsub: PubSubEngine;
+    }): IResolvers;
+  };
+  /** Object that will be called base on subscription connect/disconnect */
+  subscriptionListener?: ISubscriptionsListener;
+  /** table in which to store graphql-ws Subscriptions */
+  subscriptionStorage: ISimpleTable<IGraphqlSubscription>;
+  /** configure WebSocket-Over-Http */
+  webSocketOverHttp: {
+    /** Given a PubSubEngine publish invocation, return instructions for what to publish to a GRIP server via EPCP */
+    epcpPublishForPubSubEnginePublish(
+      publish: IPubSubEnginePublish,
+    ): Promise<IEpcpPublish[]>;
+    /** Given a graphql-ws GQL_START message, return a string that is the Grip-Channel that the GRIP server should subscribe to for updates */
+    getGripChannel(gqlStartMessage: IGraphqlWsStartMessage): string;
+  };
+}
+
+const WsOverHttpGraphqlHttpApp = (options: IGraphqlHttpAppOptions) => {
+  const { subscriptionListener } = options;
+  const schema = buildSchemaFromTypeDefinitions(options.graphql.typeDefs);
+  const pubsub = EpcpPubSubMixin({
+    epcpPublishForPubSubEnginePublish:
+      options.webSocketOverHttp.epcpPublishForPubSubEnginePublish,
+    grip: {
+      url: process.env.GRIP_URL || "http://localhost:5561",
+    },
+    schema,
+  })(new PubSub());
+  const expressApplication = express().use(
+    GraphqlWsOverWebSocketOverHttpExpressMiddleware({
+      getGripChannel: options.webSocketOverHttp.getGripChannel,
+      onSubscriptionStart:
+        subscriptionListener && subscriptionListener.onConnect,
+      subscriptionStorage: options.subscriptionStorage,
+    }),
+  );
+  const graphqlPath = "/";
+  const subscriptionsPath = "/";
+  const apolloServer = new ApolloServer({
+    resolvers: options.graphql.getResolvers({ pubsub }),
+    subscriptions: {
+      onConnect: subscriptionListener && subscriptionListener.onConnect,
+      path: subscriptionsPath,
+    },
+    typeDefs: options.graphql.typeDefs,
+  });
+  apolloServer.applyMiddleware({
+    app: expressApplication,
+    path: graphqlPath,
+  });
+  const httpServer = http.createServer(expressApplication);
+  apolloServer.installSubscriptionHandlers(httpServer);
+  return { apolloServer, graphqlPath, httpServer, subscriptionsPath };
+};
+
+/** Given a base URL and a Path, return a new URL with that path on the baseUrl (existing path on baseUrl is ignored) */
+const urlWithPath = (baseUrl: string, pathname: string): string => {
+  const parsedBaseUrl = urlModule.parse(baseUrl);
+  const newUrl = urlModule.format({ ...parsedBaseUrl, pathname });
+  return newUrl;
+};
+
+/** Test ./GraphqlWsOverWebSocketOverHttpExpressMiddleware */
+@TestFixture()
+export class GraphqlWsOverWebSocketOverHttpExpressMiddlewareTest {
+  /** test we can make a server and connect to it */
+  @AsyncTest()
+  public async testSimpleGraphqlServerWithApolloClient() {
+    const [
+      onSubscriptionConnection,
+      _,
+      latestSubscriptionChanged,
+    ] = ChangingValue();
+    const subscriptionStorage = MapSimpleTable<IGraphqlSubscription>();
+    const graphqlSchema = buildSchemaFromTypeDefinitions(
+      SimpleGraphqlApi().typeDefs,
+    );
+    const app = WsOverHttpGraphqlHttpApp({
+      graphql: {
+        getResolvers: ({ pubsub }) => SimpleGraphqlApi({ pubsub }).resolvers,
+        typeDefs: SimpleGraphqlApi().typeDefs,
+      },
+      subscriptionListener: { onConnect: onSubscriptionConnection },
+      subscriptionStorage,
+      webSocketOverHttp: {
+        epcpPublishForPubSubEnginePublish: SimpleGraphqlApiEpcpPublisher({
+          graphqlSchema,
+          subscriptionStorage,
+        }),
+        getGripChannel: SimpleGraphqlApiGripChannelNamer(),
+      },
+    });
+    await withListeningServer(app.httpServer, 0)(async ({ url }) => {
+      const urls = {
+        subscriptionsUrl: urlWithPath(url, app.subscriptionsPath),
+        url: urlWithPath(url, app.graphqlPath),
+      };
+      const apolloClient = WebSocketApolloClient(urls);
+      const { items, subscription } = itemsFromLinkObservable(
+        apolloClient.subscribe(SimpleGraphqlApiSubscriptions.postAdded()),
+      );
+      await latestSubscriptionChanged();
+      const postToAdd = {
+        author: "me",
+        comment: "first!",
+      };
+      const mutationResult = await apolloClient.mutate(
+        SimpleGraphqlApiMutations.addPost(postToAdd),
+      );
+      Expect(mutationResult.data.addPost.comment).toEqual(postToAdd.comment);
+      Expect(items.length).toEqual(1);
+    });
+    return;
+  }
+  /**
+   * test we can make a server and connect to it through pushpin.
+   * This requires that pushpin be running and have /etc/pushpin/routes configured to route traffic to serverPort, e.g. "*,debug localhost:57410,over_http"
+   */
+  @DecorateIf(
+    () => !Boolean(process.env.PUSHPIN_PROXY_URL),
+    IgnoreTest("process.env.PUSHPIN_PROXY_URL is not defined"),
+  )
+  @AsyncTest()
+  public async testSimpleGraphqlServerWithApolloClientThroughPushpin(
+    serverPort = 57410,
+    pushpinProxyUrl = process.env.PUSHPIN_PROXY_URL,
+    pushpinGripUrl = "http://localhost:5561",
+  ) {
+    if (!pushpinProxyUrl) {
+      throw new Error(`pushpinProxyUrl is required`);
+    }
+    const [
+      onSubscriptionConnection,
+      _,
+      latestSubscriptionChanged,
+    ] = ChangingValue();
+    const subscriptionStorage = MapSimpleTable<IGraphqlSubscription>();
+    const graphqlSchema = buildSchemaFromTypeDefinitions(
+      SimpleGraphqlApi().typeDefs,
+    );
+    const app = WsOverHttpGraphqlHttpApp({
+      graphql: {
+        getResolvers: ({ pubsub }) => SimpleGraphqlApi({ pubsub }).resolvers,
+        typeDefs: SimpleGraphqlApi().typeDefs,
+      },
+      subscriptionListener: { onConnect: onSubscriptionConnection },
+      subscriptionStorage,
+      webSocketOverHttp: {
+        epcpPublishForPubSubEnginePublish: SimpleGraphqlApiEpcpPublisher({
+          graphqlSchema,
+          subscriptionStorage,
+        }),
+        getGripChannel: SimpleGraphqlApiGripChannelNamer(),
+      },
+    });
+    await withListeningServer(app.httpServer, serverPort)(async ({ url }) => {
+      const urls = {
+        subscriptionsUrl: urlWithPath(pushpinProxyUrl, app.subscriptionsPath),
+        url: urlWithPath(pushpinProxyUrl, app.graphqlPath),
+      };
+      const apolloClient = WebSocketApolloClient(urls);
+      const { items, subscription } = itemsFromLinkObservable(
+        apolloClient.subscribe(SimpleGraphqlApiSubscriptions.postAdded()),
+      );
+      await latestSubscriptionChanged();
+      const postToAdd = {
+        author: "me",
+        comment: "first!",
+      };
+      const mutationResult = await apolloClient.mutate(
+        SimpleGraphqlApiMutations.addPost(postToAdd),
+      );
+      Expect(mutationResult.data.addPost.comment).toEqual(postToAdd.comment);
+      Expect(items.length).toEqual(1);
+      const firstPostAddedMessage = items[0];
+      Expect(firstPostAddedMessage.data.postAdded.comment).toEqual(
+        postToAdd.comment,
+      );
+    });
+    return;
+  }
+}
+
+if (require.main === module) {
+  cli(__filename).catch((error: Error) => {
+    throw error;
+  });
+}
+
+type Decorator = (
+  target: object,
+  propertyKey: string,
+  descriptor?: TypedPropertyDescriptor<any>,
+) => void;
+/** Conditionally apply a decorator */
+function DecorateIf(test: () => boolean, decorator: Decorator): Decorator {
+  if (test()) {
+    return decorator;
+  }
+  return () => {
+    return;
+  };
+}

--- a/src/testing-tools/ChangingValue.ts
+++ b/src/testing-tools/ChangingValue.ts
@@ -1,0 +1,29 @@
+import { EventEmitter } from "events";
+
+/** Create functions that represent a changing value and events about how it changes */
+export const ChangingValue = <T>(): [
+  (v: T) => void,
+  () => Promise<T>,
+  () => Promise<T>,
+] => {
+  let value: T | undefined;
+  let valueIsSet = false;
+  const emitter = new EventEmitter();
+  const setValue = (valueIn: T) => {
+    value = valueIn;
+    valueIsSet = true;
+    emitter.emit("value", value);
+  };
+  const getNextValue = async (): Promise<T> => {
+    return new Promise((resolve, reject) => {
+      emitter.on("value", resolve);
+    });
+  };
+  const getValue = async (): Promise<T> => {
+    if (valueIsSet) {
+      return value as T;
+    }
+    return getNextValue();
+  };
+  return [setValue, getValue, getNextValue];
+};

--- a/src/testing-tools/WebSocketApolloClient.ts
+++ b/src/testing-tools/WebSocketApolloClient.ts
@@ -1,0 +1,56 @@
+import { InMemoryCache } from "apollo-cache-inmemory";
+import { ApolloClient } from "apollo-client";
+import { split } from "apollo-link";
+import { createHttpLink } from "apollo-link-http";
+import { WebSocketLink } from "apollo-link-ws";
+import { getMainDefinition } from "apollo-utilities";
+import fetch from "cross-fetch";
+import * as WebSocket from "ws";
+
+/** Info about what URLs ApolloClient should connect to */
+export interface IApolloServerUrlInfo {
+  /** path to make subscriptions connections to */
+  subscriptionsUrl: string;
+  /** http path for graphql query/mutation endpoint */
+  url: string;
+}
+
+const WebSocketApolloClient = ({
+  url,
+  subscriptionsUrl,
+}: IApolloServerUrlInfo) => {
+  const httpLink = createHttpLink({
+    fetch: async (input, init) => {
+      const response = await fetch(input, init);
+      return response;
+    },
+    uri: url,
+  });
+  const wsLink = new WebSocketLink({
+    options: {
+      reconnect: true,
+      timeout: 999999999,
+    },
+    uri: subscriptionsUrl,
+    webSocketImpl: WebSocket,
+  });
+  const link = split(
+    // split based on operation type
+    ({ query }) => {
+      const definition = getMainDefinition(query);
+      return (
+        definition.kind === "OperationDefinition" &&
+        definition.operation === "subscription"
+      );
+    },
+    wsLink,
+    httpLink,
+  );
+  const apolloClient = new ApolloClient({
+    cache: new InMemoryCache(),
+    link,
+  });
+  return apolloClient;
+};
+
+export default WebSocketApolloClient;

--- a/src/testing-tools/itemsFromLinkObservable.ts
+++ b/src/testing-tools/itemsFromLinkObservable.ts
@@ -1,0 +1,21 @@
+import { Observable } from "apollo-link";
+
+/**
+ * Given an observable, subscribe to it and return the subscription as well as an array that will be pushed to whenever an item is sent to subscription.
+ */
+export const itemsFromLinkObservable = <T>(
+  observable: Observable<T>,
+): {
+  /** Array of items that have come from the subscription */
+  items: T[];
+  /** Subscription that can be unsubscribed to */
+  subscription: ZenObservable.Subscription;
+} => {
+  const items: T[] = [];
+  const subscription = observable.subscribe({
+    next(item) {
+      items.push(item);
+    },
+  });
+  return { items, subscription };
+};

--- a/src/testing-tools/withListeningServer.ts
+++ b/src/testing-tools/withListeningServer.ts
@@ -1,0 +1,74 @@
+import * as http from "http";
+import * as killable from "killable";
+import { AddressInfo } from "net";
+import * as url from "url";
+
+interface IListeningServerInfo {
+  /** url at which the server can be reached */
+  url: string;
+  /** host of server */
+  hostname: string;
+  /** port of server */
+  port: number;
+}
+
+const hostOfAddressInfo = (address: AddressInfo): string => {
+  const host =
+    address.address === "" || address.address === "::"
+      ? "localhost"
+      : address.address;
+  return host;
+};
+
+const urlOfServerAddress = (address: AddressInfo): string => {
+  return url.format({
+    hostname: hostOfAddressInfo(address),
+    port: address.port,
+    protocol: "http",
+  });
+};
+
+/**
+ * Given an httpServer and port, have the server listen on the port
+ * then call the provided doWorkWithServer function with info about the running server.
+ * After work is done, kill the running server to clean up.
+ */
+export const withListeningServer = (
+  httpServer: http.Server,
+  port: string | number = 0,
+) => async (
+  doWorkWithServer: (serverInfo: IListeningServerInfo) => Promise<void>,
+) => {
+  const { kill } = killable(httpServer);
+  // listen
+  await new Promise((resolve, reject) => {
+    httpServer.on("listening", resolve);
+    httpServer.on("error", error => {
+      reject(error);
+    });
+    try {
+      httpServer.listen(port);
+    } catch (error) {
+      reject(error);
+    }
+  });
+  const address = httpServer.address();
+  if (typeof address === "string" || !address) {
+    throw new Error(`Can't determine URL from address ${address}`);
+  }
+  await doWorkWithServer({
+    hostname: hostOfAddressInfo(address),
+    port: address.port,
+    url: urlOfServerAddress(address),
+  });
+  await new Promise((resolve, reject) => {
+    try {
+      kill((error: Error | undefined) => {
+        reject(error);
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+  return;
+};


### PR DESCRIPTION
* Add a good end-to-end test in here instead of only having it in apollo-demo. [GraphqlWsOverWebSocketOverHttpExpressMiddlewareTest.test.ts](https://github.com/fanout/fanout-graphql-tools/blob/d3ffc534087545ee3c5e18a7f450dc470693c232/src/subscriptions-transport-ws-over-http/GraphqlWsOverWebSocketOverHttpExpressMiddlewareTest.test.ts)
* The test makes use of a GraphQL API is the same one ('posts', 'postAdded', 'addPost') from the [apollo-server subscriptions docs](https://www.apollographql.com/docs/apollo-server/features/subscriptions/). In the repo this is in [SimpleGraphqlApi](https://github.com/fanout/fanout-graphql-tools/blob/d3ffc534087545ee3c5e18a7f450dc470693c232/src/simple-graphql-api/SimpleGraphqlApi.ts)
* Added all the [testing-tools](https://github.com/fanout/fanout-graphql-tools/tree/d3ffc534087545ee3c5e18a7f450dc470693c232/src/testing-tools) that help to make this happen from apollo-demo

It was def englightening to try to add a new GraphQL API that works using all these tools...
The grossest part is definitely [building the PubSubEngineEpcpPublisher](https://github.com/fanout/fanout-graphql-tools/blob/d3ffc534087545ee3c5e18a7f450dc470693c232/src/simple-graphql-api/SimpleGraphqlApi.ts#L160). There are probably utilities I could make to make it slightly simpler, but should probably wait until after using var-subst in pushpin because that should make it be slightly less complex.